### PR TITLE
feat: 支持压缩sdk大小

### DIFF
--- a/build.js
+++ b/build.js
@@ -2,6 +2,7 @@ var webpack = require('webpack');
 var path = require('path');
 var fs = require('fs');
 var pkg = require('./package.json');
+var TerserPlugin = require('terser-webpack-plugin');
 
 var replaceVersion = function () {
     var filePath = path.resolve(__dirname, 'src/cos.js');
@@ -32,6 +33,7 @@ var replaceDevCode = function (list) {
 replaceVersion();
 
 var config = {
+    mode: 'development',
     watch: true,
     entry: path.resolve(__dirname, './index.js'),
     output: {
@@ -65,22 +67,29 @@ if (process.env.NODE_ENV === 'production') {
         'demo-album/config.js',
         'demo-album/project.config.json',
     ]);
+    config.mode = 'production';
     config.watch = false;
     config.output.filename = 'cos-wx-sdk-v5.js';
+    config.optimization = {
+        minimize: true,
+        minimizer: [
+            new TerserPlugin({
+                terserOptions: {
+                    output: {
+                        ascii_only: true,
+                    },
+                    compress: {
+                        warnings: false,
+                    },
+                }
+            })
+        ],
+    };
     config.plugins = (config.plugins || []).concat([
         new webpack.DefinePlugin({
             'process.env': {
                 NODE_ENV: '"production"'
             }
-        }),
-        new webpack.optimize.UglifyJsPlugin({
-            sourceMap: true,
-            output: {
-                ascii_only: true,
-            },
-            compress: {
-                warnings: false,
-            },
         }),
         new webpack.LoaderOptionsPlugin({
             minimize: true

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "小程序 SDK for [腾讯云对象存储服务](https://cloud.tencent.com/product/cos)",
   "main": "demo/lib/cos-wx-sdk-v5.js",
   "scripts": {
-    "dev": "cross-env NODE_ENV=development&& node build.js",
-    "build": "cross-env NODE_ENV=production&& node build.js",
+    "dev": "cross-env NODE_ENV=development node build.js -w",
+    "build": "cross-env NODE_ENV=production node build.js -w",
     "sts.js": "node server/sts.js"
   },
   "repository": {
@@ -16,13 +16,13 @@
   "license": "ISC",
   "dependencies": {
     "mime": "^2.4.6",
-    "webpack": "^3.12.0",
     "xmldom": "^0.1.31"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",
     "express": "^4.17.1",
     "qcloud-cos-sts": "^3.0.2",
-    "uglifyjs-webpack-plugin": "^2.2.0"
+    "terser-webpack-plugin": "^4.2.3",
+    "webpack": "^4.46.0"
   }
 }


### PR DESCRIPTION
求支持压缩sdk大小，目前未压缩近400kb有点大顶不住。
```bash
1:56:41 › npm run build

> cos-wx-sdk-v5@1.1.1 build
> cross-env NODE_ENV=production node build.js -w

Hash: 15dea5fa0d77dd2dbbcd
Version: webpack 4.46.0
Time: 562ms
Built at: 11/30/2021 1:58:15 AM
           Asset     Size  Chunks             Chunk Names
cos-wx-sdk-v5.js  163 KiB       0  [emitted]  main
Entrypoint main = cos-wx-sdk-v5.js

Build complete.
```
不需要用webpack5，正常压到163kb

